### PR TITLE
rbot remote

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -7,7 +7,7 @@ rule '.1' => ['.xml'] do |t|
   sh "xsltproc -nonet -o #{t.name} /usr/share/sgml/docbook/stylesheet/xsl/nwalsh/manpages/docbook.xsl #{t.source}"
 end
 
-task :manpages => ['man/rbot.1']
+task :manpages => ['man/rbot.1', 'man/rbot-remote.1']
 
 SPECFILE = 'rbot.gemspec'
 # The Rakefile is also used after installing the gem, to build

--- a/bin/rbot-remote
+++ b/bin/rbot-remote
@@ -17,12 +17,14 @@ require 'optparse'
 user = nil
 pw = nil
 dst = nil
+function = 'say'
 uri = 'http://localhost:7268/dispatch'
 
 opts = OptionParser.new
 opts.on('-u', '--user <user>', "remote user (mandatory)") { |v| user = v }
 opts.on('-p', '--password <pw>', "remote user password (mandatory)") { |v| pw = v }
-opts.on('-d', '--destination <user or #channel>') { |v| dst = v }
+opts.on('-d', '--destination <user/#channel>', "destination of the action (mandatory)") { |v| dst = v }
+opts.on('-f', '--function <func>', "function to trigger (e.g. say, notify), default: #{function}") { |v| function = v }
 opts.on('-r', '--uri <drb uri>', "rbot url (#{uri})") { |v| uri = v }
 opts.on('-h', '--help', "this message") { |v| pw = nil } # sorry!
 opts.on('-a', '--about', "what it's all about.") { |v|
@@ -68,7 +70,7 @@ uri.password = pw
 loop {
     s = gets or break
     s.chomp!
-    resp = Net::HTTP.post_form(uri, 'command' => ['say', dst, s].join(' '))
+    resp = Net::HTTP.post_form(uri, 'command' => [function, dst, s].join(' '))
     puts [resp.code, resp.message, resp.body].join("\t")
 }
 

--- a/bin/rbot-remote
+++ b/bin/rbot-remote
@@ -1,0 +1,74 @@
+#! /usr/bin/ruby
+
+require 'uri'
+require 'net/http'
+require 'optparse'
+
+#++
+#
+# :title: webserver dispatch example script
+#
+# Author:: jsn (dmitry kim) <dmitry dot kim at gmail dot org>
+# Copyright:: (C) 2007 dmitry kim
+# License:: in public domain
+# Modified by:: Giuseppe "Oblomov" Bilotta <giuseppe dot bilotta at gmail dot com>
+# Copyright:: (C) 2020 Giuseppe Bilotta
+
+user = nil
+pw = nil
+dst = nil
+uri = 'http://localhost:7268/dispatch'
+
+opts = OptionParser.new
+opts.on('-u', '--user <user>', "remote user (mandatory)") { |v| user = v }
+opts.on('-p', '--password <pw>', "remote user password (mandatory)") { |v| pw = v }
+opts.on('-d', '--destination <user or #channel>') { |v| dst = v }
+opts.on('-r', '--uri <drb uri>', "rbot url (#{uri})") { |v| uri = v }
+opts.on('-h', '--help', "this message") { |v| pw = nil } # sorry!
+opts.on('-a', '--about', "what it's all about.") { |v|
+    puts <<EOF
+This is just a proof-of-concept example for the rbot webserver dispatch feature.
+This program reads lines of text from the standard input and sends them to a specified irc
+channel or user via rbot. Make sure you enable the webservice dispatch feature
+before use.
+
+The necessary setup is:
+    1) # create a new rbot user ("rmuser", in this example) with a password
+       # ("rmpw", in this example). in an open query to rbot:
+
+       <you> user create rmuser rmpw
+       <rbot> created botuser remote
+
+    2) # add a permission to say for your newly created remote user:
+
+       <you> allow rmuser to do say #channel message
+       <rbot> okies!
+
+    3) # run the #{$0} and type something. the message should
+       # show up on your channel / arrive as an irc private message.
+       
+       [you@yourhost ~]$ ./bin/rbot-remote -u rmuser -p rmpw -d '#your-channel'
+       hello, world!
+       <Ctrl-D>
+       [you@yourhost ~]$
+EOF
+    exit 0
+}
+opts.parse!
+
+if !pw || !user || !dst
+    puts opts.to_s
+    exit 0
+end
+
+uri = URI(uri)
+uri.user = user
+uri.password = pw
+
+loop {
+    s = gets or break
+    s.chomp!
+    resp = Net::HTTP.post_form(uri, 'command' => ['say', dst, s].join(' '))
+    puts [resp.code, resp.message, resp.body].join("\t")
+}
+

--- a/data/rbot/plugins/webhook.rb
+++ b/data/rbot/plugins/webhook.rb
@@ -227,6 +227,13 @@ class WebHookPlugin < Plugin
     num = json[:size] || json[:commits].size rescue nil
     stream_hash[:number] = _("%{num} commits") % { :num => num } if num
 
+    case event
+    when :watch
+      stream_hash[:number] ||= 'watching 👀%{watchers_count}' % json[:repository]
+    when :star
+      stream_hash[:number] ||= 'star ☆ %{watchers_count}' % json[:repository]
+    end
+
     debug stream_hash
 
     return input_stream.merge stream_hash

--- a/lib/rbot/core/webservice.rb
+++ b/lib/rbot/core/webservice.rb
@@ -531,6 +531,11 @@ class WebServiceModule < CoreBotModule
     end
 
     command = m.post['command']
+    if command.empty?
+      m.send_plaintext('wrong syntax', 400)
+      return
+    end
+
     if not m.source
       botuser = Auth::defaultbotuser
     else
@@ -544,6 +549,8 @@ class WebServiceModule < CoreBotModule
     message = Irc::PrivMessage.new(@bot, nil, user, @bot.myself, command)
 
     res = @bot.plugins.irc_delegate('privmsg', message)
+    # TODO if delegation failed due to wrong auth, it should be reported
+    # as an error, not 200 OK
 
     if m.req['Accept'] == 'application/json'
       { :reply => user.response }

--- a/lib/rbot/core/webservice.rb
+++ b/lib/rbot/core/webservice.rb
@@ -534,7 +534,7 @@ class WebServiceModule < CoreBotModule
     if not m.source
       botuser = Auth::defaultbotuser
     else
-      botuser = m.source.botuser
+      botuser = m.source
     end
     netmask = '%s!%s@%s' % [botuser.username, botuser.username, m.client]
 

--- a/man/rbot-remote.xml
+++ b/man/rbot-remote.xml
@@ -1,0 +1,217 @@
+<?xml version='1.0' encoding='utf-8'?>
+<!DOCTYPE refentry PUBLIC "-//OASIS//DTD DocBook XML V4.2//EN"
+"http://www.oasis-open.org/docbook/xml/4.2/docbookx.dtd" [
+
+<!--
+
+Process this file with an XSLT processor: `xsltproc \
+-''-nonet /usr/share/sgml/docbook/stylesheet/xsl/nwalsh/\
+manpages/docbook.xsl manpage.dbk'.  A manual page
+<package>.<section> will be generated.  You may view the
+manual page with: nroff -man <package>.<section> | less'.  A
+typical entry in a Makefile or Makefile.am is:
+
+DB2MAN=/usr/share/sgml/docbook/stylesheet/xsl/nwalsh/\
+manpages/docbook.xsl
+XP=xsltproc -''-nonet
+
+manpage.1: manpage.dbk
+        $(XP) $(DB2MAN) $<
+    
+The xsltproc binary is found in the xsltproc package.  The
+XSL files are in docbook-xsl.  Please remember that if you
+create the nroff version in one of the debian/rules file
+targets (such as build), you will need to include xsltproc
+and docbook-xsl in your Build-Depends control field.
+
+-->
+
+  <!-- Fill in your name for FIRSTNAME and SURNAME. -->
+  <!ENTITY dhfirstname "<firstname>Marc</firstname>">
+  <!ENTITY dhsurname   "<surname>Dequènes</surname>">
+  <!ENTITY gbgname     "<firstname>Giuseppe</firstname>">
+  <!ENTITY gbfname     "<surname>Bilotta</surname>">
+  <!-- Please adjust the date whenever revising the manpage. -->
+  <!ENTITY dhdate      "<date>20100701</date>">
+  <!-- SECTION should be 1-8, maybe w/ subsection other parameters are
+       allowed: see man(7), man(1). -->
+  <!ENTITY dhsection   "<manvolnum>1</manvolnum>">
+  <!ENTITY dhemail     "<email>Duck@DuckCorp.org</email>">
+  <!ENTITY gbemail     "<email>giuseppe.bilotta@gmail.com</email>">
+  <!ENTITY dhusername  "Marc Dequènes (Duck)">
+  <!ENTITY gbusername  "Giuseppe Bilotta">
+  <!ENTITY dhucapp     "<refentrytitle>RBOT-REMOTE</refentrytitle>">
+  <!ENTITY dhapp       "rbot-remote">
+  <!ENTITY dhpackage   "rbot">
+  <!ENTITY dhpackageversion "0.9.15">
+
+  <!ENTITY debian      "<productname>Debian</productname>">
+  <!ENTITY gnu         "<acronym>GNU</acronym>">
+  <!ENTITY gpl         "&gnu; <acronym>GPL</acronym>">
+]>
+
+<refentry id="&dhapp;.1">
+
+  <refentryinfo>
+    <productname>&dhapp;</productname>
+    <authorgroup>
+      <author>
+        &dhfirstname;
+        &dhsurname;
+        &dhemail;
+        <contrib>&debian; package maintainer</contrib>
+      </author>
+      <author>
+        &gbgname;
+        &gbfname;
+        &gbemail;
+        <contrib>&dhapp; maintainer</contrib>
+      </author>
+    </authorgroup>
+    <copyright>
+      <year>2004-2009</year>
+      <holder>&dhusername;</holder>
+    </copyright>
+    <copyright>
+      <year>2010</year>
+      <holder>&gbusername;</holder>
+    </copyright>
+    &dhdate;
+  </refentryinfo>
+
+  <refmeta>
+    &dhucapp;
+    &dhsection;
+    <refmiscinfo class="manual">&dhapp; man page</refmiscinfo>
+    <refmiscinfo class="source">&dhpackage;</refmiscinfo>
+    <refmiscinfo class="version">&dhpackageversion;</refmiscinfo>
+  </refmeta>
+
+  <refnamediv>
+    <refname>&dhapp;</refname>
+
+    <refpurpose>IRC bot written in ruby</refpurpose>
+  </refnamediv>
+
+  <refsynopsisdiv>
+    <cmdsynopsis>
+      <command>&dhapp;</command>
+
+      <group choice="req">
+        <group choice="req">
+          <arg><option>-u USER</option></arg>
+          <arg><option>--user USER</option></arg>
+        </group>
+        <group choice="req">
+          <arg><option>-p PASSWORD</option></arg>
+          <arg><option>--password PASSWORD</option></arg>
+        </group>
+      </group>
+      <group choice="opt">
+        <group choice="req">
+          <arg><option>-d DEST</option></arg>
+          <arg><option>--destination DEST</option></arg>
+        </group>
+        <group choice="req">
+          <arg><option>-r DRB_URI</option></arg>
+          <arg><option>--uri DRB_URI</option></arg>
+        </group>
+        <group choice="req">
+          <arg><option>-h</option></arg>
+          <arg><option>--help</option></arg>
+        </group>
+        <group choice="req">
+          <arg><option>-a</option></arg>
+          <arg><option>--about</option></arg>
+        </group>
+      </group>
+
+    </cmdsynopsis>
+  </refsynopsisdiv>
+  <refsect1>
+    <title>DESCRIPTION</title>
+
+    <para><command>&dhapp;</command> is a proof-of-concept example for
+      rbot druby-based api. This program reads lines of text from the standard
+      input and sends them to a specified irc channel or user via rbot.
+    </para>
+
+    <para>Make sure you have the remotectl plugin loaded and assigned the needed
+      rights to the user before use.
+    </para>
+
+  </refsect1>
+  <refsect1>
+    <title>OPTIONS</title>
+
+    <para>This program follow the usual &gnu; command line syntax,
+      with long options starting with two dashes (`-').  A summary of
+      options is included below.</para>
+
+    <variablelist>
+      <varlistentry>
+        <term><option>-u <parameter>USER</parameter></option></term>
+        <term><option>--user <parameter>USER</parameter></option></term>
+        <listitem>
+          <para>Remote user.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-p <parameter>PASSWORD</parameter></option></term>
+        <term><option>--password <parameter>PASSWORD</parameter></option></term>
+        <listitem>
+          <para>Remote user password.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-d <parameter>DEST</parameter></option></term>
+        <term><option>--destination <parameter>DEST</parameter></option></term>
+        <listitem>
+          <para>Destination for message (user or channel).</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-r <parameter>DRB_URI</parameter></option></term>
+        <term><option>--uri <parameter>DRB_URI</parameter></option></term>
+        <listitem>
+          <para>Rbot url.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-h</option></term>
+        <term><option>--help</option></term>
+        <listitem>
+          <para>Show summary of options.</para>
+        </listitem>
+      </varlistentry>
+
+      <varlistentry>
+        <term><option>-a</option></term>
+        <term><option>--about</option></term>
+        <listitem>
+          <para>Tell what it's all about.</para>
+        </listitem>
+      </varlistentry>
+    </variablelist>
+  </refsect1>
+  <refsect1>
+    <title>VERSION</title>
+
+    <para>This manual page was written by &dhusername; &dhemail; for
+      the &debian; system (but may be used by others).  Permission is
+      granted to copy, distribute and/or modify this document under
+      the terms of the &gnu; General Public License, Version 3 or
+      any later version published by the Free Software Foundation.
+    </para>
+    <para>
+      On Debian systems, the complete text of the GNU General Public
+      License can be found in /usr/share/common-licenses/GPL.
+    </para>
+
+  </refsect1>
+</refentry>
+

--- a/rbot.gemspec
+++ b/rbot.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
 	  'INSTALL',
 	  'Usage_en.txt',
 	  'man/rbot.xml',
+	  'man/rbot-remote.xml',
 	  'setup.rb',
 	  'launch_here.rb',
 	  'po/*.pot',
@@ -34,7 +35,7 @@ Gem::Specification.new do |s|
   ]
 
   s.bindir = 'bin'
-  s.executables = ['rbot', 'rbotdb']
+  s.executables = ['rbot', 'rbotdb', 'rbot-remote']
   s.extensions = 'Rakefile'
 
   s.rdoc_options = ['--exclude', 'post-install.rb',


### PR DESCRIPTION
This patchset fixes some minor issues in the webservice dispatch feature, and reintroduces the rbot-remote external utility, both as an example usage of the feature, and for backwards compatibility with the previous rbot versions (some users were actually using the feature for external announcements in channels).